### PR TITLE
#3 Fix error handler methods chaining in index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,10 +31,11 @@ proxy.on("proxyReq", function (proxyReq, req, res, options) {
 });
 
 var sendError = function (res, err) {
-  return res.status(500).send({
+  res.writeHead(500);
+  res.write(JSON.stringify({
     error: err,
     message: "An error occured in the proxy",
-  });
+  }));
 };
 
 // error handling


### PR DESCRIPTION
JSON.stringify is maybe superfluous.
To be yourself in a situation of remote server error, provide a bogus path to the proxy request (eg. http://localhost:8080/v1/bogus ).